### PR TITLE
Api GW url changes in api service / tests / mocks, according to the c…

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -27,7 +27,7 @@ describe('Test app authentication based rendering', () => {
 
     // once login button clicked, user should be directed to sinuna authentication (api gateway route)
     expect(window.location.assign).toBeCalledWith(
-      `${api.AUTH_GW_ENDPOINT}/auth/openid/login-request?appContext=${appContextUrlEncoded}`
+      `${api.AUTH_GW_ENDPOINT}/auth/openid/sinuna/login-request?appContext=${appContextUrlEncoded}`
     );
 
     // login button should be disabled when login action is clicked
@@ -87,7 +87,7 @@ describe('Test app authentication based rendering', () => {
 
     // once log pit button clicked, user should be directed to sinuna authentication log out (api gateway route)
     expect(window.location.assign).toBeCalledWith(
-      `${api.AUTH_GW_ENDPOINT}/auth/openid/logout-request?appContext=${appContextUrlEncoded}`
+      `${api.AUTH_GW_ENDPOINT}/auth/openid/sinuna/logout-request?appContext=${appContextUrlEncoded}`
     );
 
     // log out button text should be changed to 'Kirjaudutaan ulos...' once logout redirect happens

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -59,23 +59,23 @@ axiosInstance.interceptors.request.use(config => {
 function directToAuthGwLogin(authProvider: AuthProvider) {
   const authRoute = authProvider === AuthProvider.SINUNA ? 'openid' : 'saml2';
   window.location.assign(
-    `${AUTH_GW_ENDPOINT}/auth/${authRoute}/login-request?appContext=${appContextUrlEncoded}`
+    `${AUTH_GW_ENDPOINT}/auth/${authRoute}/${authProvider}/login-request?appContext=${appContextUrlEncoded}`
   );
 }
 
 function directToAuthGwLogout(authProvider: AuthProvider) {
   const authRoute = authProvider === AuthProvider.SINUNA ? 'openid' : 'saml2';
   window.location.assign(
-    `${api.AUTH_GW_ENDPOINT}/auth/${authRoute}/logout-request?appContext=${appContextUrlEncoded}`
+    `${api.AUTH_GW_ENDPOINT}/auth/${authRoute}/${authProvider}/logout-request?appContext=${appContextUrlEncoded}`
   );
 }
 
-async function getAuthToken(authPayload: {
+async function getSinunaAuthToken(authPayload: {
   loginCode: string;
   appContext: string;
 }) {
   return axiosInstance.post(
-    `${AUTH_GW_ENDPOINT}/auth/openid/auth-token-request`,
+    `${AUTH_GW_ENDPOINT}/auth/openid/sinuna/auth-token-request`,
     authPayload
   );
 }
@@ -86,7 +86,7 @@ async function getUserInfo(
 ) {
   const authRoute = authProvider === AuthProvider.SINUNA ? 'openid' : 'saml2';
   return axiosInstance.post(
-    `${AUTH_GW_ENDPOINT}/auth/${authRoute}/user-info-request`,
+    `${AUTH_GW_ENDPOINT}/auth/${authRoute}/${authProvider}/user-info-request`,
     payload,
     {
       withCredentials: true,
@@ -110,7 +110,7 @@ const api = {
   OPEN_DATA_URL,
   directToAuthGwLogin,
   directToAuthGwLogout,
-  getAuthToken,
+  getSinunaAuthToken,
   getUserInfo,
   getKeyFigures,
   getData,

--- a/src/components/AuthHandler/AuthHandler.tsx
+++ b/src/components/AuthHandler/AuthHandler.tsx
@@ -36,7 +36,7 @@ export default function AuthHandler() {
   const handleSinunaAuthentication = useCallback(async () => {
     try {
       // get token
-      const tokenResponse = await api.getAuthToken({
+      const tokenResponse = await api.getSinunaAuthToken({
         loginCode: loginCodeParam as string,
         appContext: appContextUrlEncoded,
       });

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -41,13 +41,13 @@ export const handlers = [
     );
   }),
   rest.post(
-    `${api.AUTH_GW_ENDPOINT}/auth/openid/auth-token-request`,
+    `${api.AUTH_GW_ENDPOINT}/auth/openid/sinuna/auth-token-request`,
     (req, res, ctx) => {
       return res(ctx.json({ token: '123-random-token' }));
     }
   ),
   rest.post(
-    `${api.AUTH_GW_ENDPOINT}/auth/openid/user-info-request`,
+    `${api.AUTH_GW_ENDPOINT}/auth/openid/sinuna/user-info-request`,
     (req, res, ctx) => {
       return res(ctx.json({ email: 'aku.ankka@email.com' }));
     }


### PR DESCRIPTION
Changed API GW auth route urls to include provider, according to API GW changes. Changes made to api service, tests, mocks. Also renamed api service function from getAuthToken -> getSinunaAuthToken.

AuthProvider enum for reference:

enum AuthProvider {
  SINUNA = 'sinuna',
  SUOMIFI = 'suomifi',
}

