### PR TITLE
feat: remove the obsolete sinuna idToken-exception

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -50,11 +50,7 @@ axiosInstance.interceptors.request.use(config => {
   if (config.url !== undefined && config.headers !== undefined) {
     if (authTokens && [OPEN_DATA_URL].includes(config.url)) {
       // The token that is used to authorize the user in the protected, external API queries
-      let authorizationToken = authTokens.idToken;
-      // The exception: Sinuna does not operate with idToken, use accessToken instead
-      if (provider === AuthProvider.SINUNA) {
-        authorizationToken = authTokens.accessToken;
-      }
+      const authorizationToken = authTokens.idToken;
 
       config.headers.Authorization = authorizationToken
         ? `Bearer ${authorizationToken}`


### PR DESCRIPTION
The UI changes needed by the https://github.com/Virtual-Finland-Development/authentication-gw/pull/8

When getting productizer data using auth-headers, sinuna was the only provider method that did not use the *idToken* for verify-purpouses: no longer the case. This PR removes the exception. 
